### PR TITLE
Rename pathContext to pageContext

### DIFF
--- a/src/components/Site/SEO.js
+++ b/src/components/Site/SEO.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 import Helmet from 'react-helmet';
 
-const SEO = ({ location: { pathname }, pathContext: { frontmatter }, seo }) => {
+const SEO = ({ location: { pathname }, pageContext: { frontmatter }, seo }) => {
   const {
     site: { siteMetadata },
   } = useStaticQuery(graphql`

--- a/src/components/Site/SEO.js
+++ b/src/components/Site/SEO.js
@@ -53,7 +53,7 @@ SEO.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,
-  pathContext: PropTypes.shape({
+  pageContext: PropTypes.shape({
     frontmatter: PropTypes.object,
   }),
   seo: PropTypes.shape({
@@ -68,7 +68,7 @@ SEO.propTypes = {
 };
 
 SEO.defaultProps = {
-  pathContext: {},
+  pageContext: {},
   seo: {},
 };
 


### PR DESCRIPTION
In Gatsby v2, pathContext is deprecated in favor of pageContext.
https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext